### PR TITLE
Feature/multi file upload

### DIFF
--- a/filament/Resources/TrainableResource/Pages/Training.php
+++ b/filament/Resources/TrainableResource/Pages/Training.php
@@ -103,7 +103,9 @@ class Training extends Page
 
             if ($this->upload)
             {
-                $this->text = $this->extractUploadedText();
+                $this->text = array_reduce($this->upload, function ($carry, $item) {
+                    return $carry .= file_get_contents($item->getRealPath());
+                });
             }
 
             Savvy::trainInBatches($this->record, $this->text, $this->record->id);
@@ -126,36 +128,5 @@ class Training extends Page
         ]);
 
         return redirect()->back();
-    }
-
-    private function extractUploadedText(): string
-    {
-        if (count($this->upload) === 1)
-        {
-            $contents = file_get_contents($this->upload[0]->getRealPath());
-
-            if (!is_string($contents))
-            {
-                throw new \Exception('File contents could not be read');
-            }
-
-            return $contents;
-        }
-
-        $text = '';
-
-        foreach ($this->upload as $upload)
-        {
-            $contents = file_get_contents($upload->getRealPath());
-
-            if (!is_string($contents))
-            {
-                throw new \Exception('File contents could not be read');
-            }
-
-            $text .= $contents;
-        }
-
-        return $text;
     }
 }

--- a/filament/Resources/TrainableResource/Pages/Training.php
+++ b/filament/Resources/TrainableResource/Pages/Training.php
@@ -68,6 +68,7 @@ class Training extends Page
                                 ->label('Upload')
                                 ->acceptedFileTypes(['text/plain'])
                                 ->disk('local')
+                                ->multiple()
                                 ->preserveFilenames()
                         ]),
                 ]),
@@ -102,15 +103,7 @@ class Training extends Page
 
             if ($this->upload)
             {
-                $upload   = array_shift($this->upload);
-                $contents = file_get_contents($upload->getRealPath());
-
-                if (!is_string($contents))
-                {
-                    throw new \Exception('File contents could not be read');
-                }
-
-                $this->text = $contents;
+                $this->text = $this->extractUploadedText();
             }
 
             Savvy::trainInBatches($this->record, $this->text, $this->record->id);
@@ -133,5 +126,36 @@ class Training extends Page
         ]);
 
         return redirect()->back();
+    }
+
+    private function extractUploadedText(): string
+    {
+        if (count($this->upload) === 1)
+        {
+            $contents = file_get_contents($this->upload[0]->getRealPath());
+
+            if (!is_string($contents))
+            {
+                throw new \Exception('File contents could not be read');
+            }
+
+            return $contents;
+        }
+
+        $text = '';
+
+        foreach ($this->upload as $upload)
+        {
+            $contents = file_get_contents($upload->getRealPath());
+
+            if (!is_string($contents))
+            {
+                throw new \Exception('File contents could not be read');
+            }
+
+            $text .= $contents;
+        }
+
+        return $text;
     }
 }

--- a/src/Models/Trainable.php
+++ b/src/Models/Trainable.php
@@ -4,6 +4,7 @@ namespace SavvyAI\Models;
 
 use DateTime;
 use Illuminate\Contracts\Database\Eloquent\Builder;
+use SavvyAI\Features\Training\DelimiterSplitter;
 use SavvyAI\Features\Training\Splitter;
 use SavvyAI\Features\Training\Vectorizer;
 
@@ -57,6 +58,11 @@ class Trainable extends Model implements \SavvyAI\Contracts\TrainableContract
 
     public function getTextSplitter(): Splitter
     {
+        if (!empty($this->splitAt))
+        {
+            return new DelimiterSplitter($this->splitAt);
+        }
+
         return new Splitter();
     }
 


### PR DESCRIPTION
Support for uploading multiple training files

The filament training page has been updated to support multiple files when uploading training files. The logic for extracting the text from upload(s) has been moved to a private `extractUploadedText()`.  This will function as normal if there is only one file is uploaded, and loop over multiple files if more than one was uploaded.

Additionally, the package's `Trainable` model's `getSplitter` method has been updated to use the delimiter splitter if the trainable has a `splitAt` value. Sounds like we will revisit how this works, but this lets training work with a splitter from the package without having to define your own trainable model and custom get splitter method.