### PR TITLE
Feature/training status and reset

### DIFF
--- a/filament/Resources/TrainableResource/Pages/Training.php
+++ b/filament/Resources/TrainableResource/Pages/Training.php
@@ -132,6 +132,6 @@ class Training extends Page
             'is_training' => false,
         ]);
 
-        return redirect()->route('filament.resources.trainables.training', $this->record);
+        return redirect()->route('filament.resources.trainables.view', $this->record);
     }
 }

--- a/filament/Resources/TrainableResource/Pages/Training.php
+++ b/filament/Resources/TrainableResource/Pages/Training.php
@@ -132,6 +132,6 @@ class Training extends Page
             'is_training' => false,
         ]);
 
-        return redirect()->back();
+        return redirect()->route('filament.resources.trainables.training', $this->record);
     }
 }

--- a/resources/views/filament/resources/trainable-resource/pages/training.blade.php
+++ b/resources/views/filament/resources/trainable-resource/pages/training.blade.php
@@ -1,72 +1,20 @@
 <x-filament::page>
-    @if($isTraining)
-        <div class="training w-full py-6">
+<form wire:submit.prevent="submit">
+    {{ $this->form }}
 
-            <div class="flex flex-col gap-8">
-
-                {{-- processing --}}
-                <div class="flex items-center gap-4">
-                    <div class="relative">
-                        <div @class(['!bg-primary-500 !text-white' => $isProcessing, 'circle w-10 h-10 mx-auto bg-white border-2 border-slate-200 rounded-full text-lg text-slate-600 flex items-center'])>
-                            <div class="text-center w-full">
-                                <svg class="w-full fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-                                    <path class="heroicon-ui" d="M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-2.3-8.7l1.3 1.29 3.3-3.3a1 1 0 0 1 1.4 1.42l-4 4a1 1 0 0 1-1.4 0l-2-2a1 1 0 0 1 1.4-1.42z"/>
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="text-lg">Processing Text</div>
-                </div>
-
-                {{-- generating --}}
-                <div class="flex items-center gap-4">
-                    <div class="relative">
-                        <div @class(['!bg-primary-500 !text-white' => $isGenerating, 'circle w-10 h-10 mx-auto bg-white border-2 border-slate-200 rounded-full text-lg text-slate-600 flex items-center'])>
-                            <div class="text-center w-full">
-                                <svg class="w-full fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-                                    <path class="heroicon-ui" d="M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-2.3-8.7l1.3 1.29 3.3-3.3a1 1 0 0 1 1.4 1.42l-4 4a1 1 0 0 1-1.4 0l-2-2a1 1 0 0 1 1.4-1.42z"/>
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="text-lg">Generating Vocabulary</div>
-                </div>
-
-                {{-- complete --}}
-                <div class="flex items-center gap-4">
-                    <div class="relative">
-                        <div @class(['!bg-primary-500 !text-white' => $isComplete, 'circle w-10 h-10 mx-auto bg-white border-2 border-slate-200 rounded-full text-lg text-slate-600 flex items-center'])>
-                            <div class="text-center w-full">
-                                <svg class="w-full fill-current" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-                                    <path class="heroicon-ui" d="M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20zm0-2a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm-2.3-8.7l1.3 1.29 3.3-3.3a1 1 0 0 1 1.4 1.42l-4 4a1 1 0 0 1-1.4 0l-2-2a1 1 0 0 1 1.4-1.42z"/>
-                                </svg>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="text-lg">Training Complete</div>
-                </div>
-            </div>
-        </div>
-
-        @if($isComplete)
-            <div class="text-center mt-8">
-                <x-filament::button tag="a" href="{{ $backUrl }}">
-                    Go to {{ $record->name }}
-                </x-filament::button>
-            </div>
-        @endif
-    @else
-        <form wire:submit.prevent="submit">
-            {{ $this->form }}
-
-            <div class="text-right mt-8">
-                <x-filament::button type="submit">
-                    Start Training
-                </x-filament::button>
-            </div>
-        </form>
-    @endif
+    <div class="text-right mt-8" wire:loading.remove wire:target="submit">
+        <x-filament::button type="submit">
+            Start Training
+        </x-filament::button>
+    </div>
+    <div class="text-right mt-8" wire:loading wire:target="submit">
+        <x-filament::button type="submit" disabled>
+            <svg class="inline animate-spin -ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            </svg>
+            Training...
+        </x-filament::button>
+    </div>
+</form>
 </x-filament::page>

--- a/resources/views/filament/resources/trainable-resource/pages/training.blade.php
+++ b/resources/views/filament/resources/trainable-resource/pages/training.blade.php
@@ -2,11 +2,14 @@
 <form wire:submit.prevent="submit">
     {{ $this->form }}
 
+    <br/>
+
     <div class="text-right mt-8" wire:loading.remove wire:target="submit">
         <x-filament::button type="submit">
             Start Training
         </x-filament::button>
     </div>
+
     <div class="text-right mt-8" wire:loading.block wire:target="submit">
         <x-filament::button disabled>
             <svg class="inline animate-spin -ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">

--- a/resources/views/filament/resources/trainable-resource/pages/training.blade.php
+++ b/resources/views/filament/resources/trainable-resource/pages/training.blade.php
@@ -7,8 +7,8 @@
             Start Training
         </x-filament::button>
     </div>
-    <div class="text-right mt-8" wire:loading wire:target="submit">
-        <x-filament::button type="submit" disabled>
+    <div class="text-right mt-8" wire:loading.block wire:target="submit">
+        <x-filament::button disabled>
             <svg class="inline animate-spin -ml-1 mr-2 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                 <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>


### PR DESCRIPTION
* The "Start Training" button now has some space between it and the form container above it.
* Once submitted, the button gets swapped for a "Training..." disabled button with a loading spinner.
* The view with different status updates while training has been removed, the only thing that changes while you are training is the button changing to a loading state.
* Once training is complete the user is redirected back to the Trainable page showing the trained data.

Potential gotchas:
* Livewire's `wire:loading` causes the loading/training button to flash back to its normal "Start Training" state before the redirect takes effect.
* The space between the buttons and the form container above them is via a `<br/>` between them, I could not get anything else to work (margin top, move buttons outside form and target with `form="trainingForm"`)