### PR TITLE
Feature/welcome message

### DIFF
--- a/database/migrations/2023_05_17_044349_add_welcome_message_to_chatbots.php
+++ b/database/migrations/2023_05_17_044349_add_welcome_message_to_chatbots.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::table('chatbots', function (Blueprint $table) {
             // add welcome_message column after trainable_id
             $table->text('welcome_message')->after('trainable_id')->nullable();
-            $table->text('welcome_prompts')->after('welcome_message')->nullable();
+            $table->json('welcome_prompts')->after('welcome_message')->nullable();
         });
     }
 

--- a/database/migrations/2023_05_17_044349_add_welcome_message_to_chatbots.php
+++ b/database/migrations/2023_05_17_044349_add_welcome_message_to_chatbots.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('chatbots', function (Blueprint $table) {
+            // add welcome_message column after trainable_id
+            $table->text('welcome_message')->after('trainable_id')->nullable();
+            $table->text('welcome_prompts')->after('welcome_message')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('chatbots', function (Blueprint $table) {
+            //
+        });
+    }
+};

--- a/filament/Resources/ChatbotResource.php
+++ b/filament/Resources/ChatbotResource.php
@@ -23,15 +23,23 @@ class ChatbotResource extends Resource
     public static function form(Form $form): Form
     {
         return $form
-            ->schema([
-                Card::make()
-                    ->schema([
-                        Forms\Components\Select::make('trainable_id')
-                            ->relationship('trainable', 'name')
-                            ->columnSpanFull()
-                    ])
-                    ->columns(2)
-            ]);
+        ->schema([
+            Card::make()
+                ->schema([
+                    Forms\Components\Select::make('trainable_id')
+                        ->relationship('trainable', 'name')
+                        ->columnSpanFull(),
+                    Forms\Components\TextArea::make('welcome_message')
+                        ->columnSpanFull()
+                        ->disableAutocomplete(),
+                    Forms\Components\TextArea::make('welcome_prompts')
+                        ->columnSpanFull()
+                        ->hint('Each prompt MUST be on its own line.')
+                        ->hintIcon('heroicon-o-information-circle')
+                        ->disableAutocomplete(),
+                ])
+                ->columns(2)
+        ]);
     }
 
     public static function table(Table $table): Table

--- a/filament/Resources/ChatbotResource.php
+++ b/filament/Resources/ChatbotResource.php
@@ -32,11 +32,12 @@ class ChatbotResource extends Resource
                     Forms\Components\TextArea::make('welcome_message')
                         ->columnSpanFull()
                         ->disableAutocomplete(),
-                    Forms\Components\TextArea::make('welcome_prompts')
+                    Forms\Components\Repeater::make('welcome_prompts')
+                        ->schema([
+                            Forms\Components\TextInput::make('prompt')->required(),
+                        ])
                         ->columnSpanFull()
-                        ->hint('Each prompt MUST be on its own line.')
-                        ->hintIcon('heroicon-o-information-circle')
-                        ->disableAutocomplete(),
+                        ->maxItems(3)
                 ])
                 ->columns(2)
         ]);

--- a/src/Models/Chatbot.php
+++ b/src/Models/Chatbot.php
@@ -24,6 +24,10 @@ class Chatbot extends Model implements ChatDelegateContract
 {
     use Delegatable;
 
+    protected $casts = [
+        'welcome_prompts' => 'array'
+    ];
+
     protected $fillable = [
         'trainable_id',
         'welcome_message',

--- a/src/Models/Chatbot.php
+++ b/src/Models/Chatbot.php
@@ -57,15 +57,6 @@ class Chatbot extends Model implements ChatDelegateContract
         return sprintf('%s Chatbot', $this->trainable->value('name'));
     }
 
-    public function getWelcomePrompts(): array
-    {
-        $prompts = array_map(function ($prompt) {
-            return trim($prompt);
-        }, explode("\n", $this->welcome_prompts));
-
-        return array_filter($prompts);
-    }
-
     public function trainable(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Trainable::class);

--- a/src/Models/Chatbot.php
+++ b/src/Models/Chatbot.php
@@ -26,6 +26,8 @@ class Chatbot extends Model implements ChatDelegateContract
 
     protected $fillable = [
         'trainable_id',
+        'welcome_message',
+        'welcome_prompts'
     ];
 
     protected $appends = ['name'];

--- a/src/Models/Chatbot.php
+++ b/src/Models/Chatbot.php
@@ -57,6 +57,15 @@ class Chatbot extends Model implements ChatDelegateContract
         return sprintf('%s Chatbot', $this->trainable->value('name'));
     }
 
+    public function getWelcomePrompts(): array
+    {
+        $prompts = array_map(function ($prompt) {
+            return trim($prompt);
+        }, explode("\n", $this->welcome_prompts));
+
+        return array_filter($prompts);
+    }
+
     public function trainable(): \Illuminate\Database\Eloquent\Relations\BelongsTo
     {
         return $this->belongsTo(Trainable::class);


### PR DESCRIPTION
Note: Has not been integrated with actual chat yet.

* Chatbots have two new fields: `welcome_message` and `welcome_prompts`
* Repeater field is used as filament input for welcome prompts
* You can add up to 3 welcome prompts

My idea for integrating this with an actual chat is to add a message to the top of the chat's history (if the chatbot has a welcome message) with the chatbot's welcome message text. Then, if the chatbot has any welcome prompts, the client will receive an array of them it can render as a list below the welcome message.