### PR TITLE
Make trainable edit page redirect back to trainable page after edit

### DIFF
--- a/filament/Resources/TrainableResource/Pages/EditTrainable.php
+++ b/filament/Resources/TrainableResource/Pages/EditTrainable.php
@@ -21,4 +21,9 @@ class EditTrainable extends EditRecord
     {
         return [];
     }
+
+    protected function getRedirectUrl(): string
+    {
+        return route('filament.resources.trainables.view', $this->record->id);
+    }
 }


### PR DESCRIPTION
You will now be redirected back to the trainable's page after saving an edit on the edit page.

Filament's `getRedirectUrl()` was used on the edit resource to return the trainable view route as a url string.