### PR TITLE
Update InteractsWithAIService to validate replies again

### DIFF
--- a/src/Traits/InteractsWithAIService.php
+++ b/src/Traits/InteractsWithAIService.php
@@ -127,19 +127,19 @@ EOT;
             ], $messages),
         ]);
 
-        return ChatReply::fromAIServiceResponse((array) $result);
+        $reply = ChatReply::fromAIServiceResponse((array) $result);
 
-//        if ($reply->isContextUnknown())
-//        {
-//            throw new UnknownContextException($reply->content());
-//        }
-//
-//        if (!$reply->isOnTopic())
-//        {
-//            throw new OffTopicException($reply->content());
-//        }
+       if ($reply->isContextUnknown())
+       {
+           throw new UnknownContextException($reply->content());
+       }
 
-        // return $reply;
+       if (!$reply->isOnTopic())
+       {
+           throw new OffTopicException($reply->content());
+       }
+
+        return $reply;
     }
 
     /**


### PR DESCRIPTION
Validating replies to be on-topic was disabled a while back. This PR re-enables this feature so that the app can re-delegate to the correct delegate if necessary.